### PR TITLE
Update init to handle connect-src changes in 1.9.1

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-your_spotify-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-your_spotify-config/run
@@ -7,23 +7,29 @@ cp "$VAR_PATH/variables-template.js" "$VAR_PATH/variables.js"
 
 export API_ENDPOINT="${APP_URL}/api"
 
-if [[ -n "$API_ENDPOINT" ]]; then
-    echo "Setting API Endpoint to '$API_ENDPOINT'"
-    sed -i "s;__API_ENDPOINT__;$API_ENDPOINT;g" "$VAR_PATH/variables.js"
-
-    # Editing meta image urls
-    sed -i "s;image\" content=\"\(.[^\"]*\);image\" content=\"$API_ENDPOINT/static/your_spotify_1200.png;g" "$VAR_PATH/index.html"
-
-    # Restricting connect-src to API_ENDPOINT with a trailing /
-    API_ENDPOINT_ENDING_WITH_SLASH=$API_ENDPOINT
-    if [[ "$API_ENDPOINT_ENDING_WITH_SLASH" != */ ]]
-    then
-        API_ENDPOINT_ENDING_WITH_SLASH="$API_ENDPOINT_ENDING_WITH_SLASH/"
-    fi
-    sed -i "s#connect-src \(.*\);#connect-src $API_ENDPOINT_ENDING_WITH_SLASH;#g" "$VAR_PATH/index.html"
-else
+if [[ -z "$API_ENDPOINT" ]]
+then
     echo "API_ENDPOINT is not defined, web app won't work"
     exit 1
 fi
+
+echo "Setting API Endpoint to '$API_ENDPOINT'"
+sed -i "s;__API_ENDPOINT__;$API_ENDPOINT;g" "$VAR_PATH/variables.js"
+
+# Editing meta image urls
+sed -i "s;image\" content=\"\(.[^\"]*\);image\" content=\"$API_ENDPOINT/static/your_spotify_1200.png;g" "$VAR_PATH/index.html"
+
+# Restricting connect-src to API_ENDPOINT with a trailing /, or to * if hostname has an _
+CSP_CONNECT_SRC=$API_ENDPOINT
+if [[ "$CSP_CONNECT_SRC" == *_*.*.* ]]
+then
+    echo "It seems that your subdomain has an underscore in it, falling back to less strict CSP"
+    CSP_CONNECT_SRC="*"
+elif ! echo "$CSP_CONNECT_SRC" | grep -q "/$"
+then
+    CSP_CONNECT_SRC="$CSP_CONNECT_SRC/"
+fi
+
+sed -i "s#connect-src \(.*\);#connect-src 'self' $CSP_CONNECT_SRC;#g" "$VAR_PATH/index.html"
 
 HOME="/app"


### PR DESCRIPTION
https://github.com/Yooooomi/your_spotify/commit/50727030902d60c6afe8e6a2e154ad94f253cc6a

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-your_spotify/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:

Update init to handle connect-src changes in 1.9.1 -> https://github.com/Yooooomi/your_spotify/releases/tag/1.9.1

## Benefits of this PR and context:

your_spotify 1.9.1 brings a little fix for subdomains with underscore in it. This brings the fix to the linuxserver.io image too.

## How Has This Been Tested?

Tested by building the docker image locally and testing with both a subdomain with and without underscore. All works fine.

## Source / References:

https://github.com/Yooooomi/your_spotify/releases/tag/1.9.1
https://github.com/Yooooomi/your_spotify/pull/373
https://github.com/Yooooomi/your_spotify/pull/373/commits/50727030902d60c6afe8e6a2e154ad94f253cc6a
